### PR TITLE
Fix workflow push permissions

### DIFF
--- a/.github/workflows/ics.yml
+++ b/.github/workflows/ics.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   ics:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- allow the scheduled workflow to push updates by granting `contents: write`

## Testing
- `pnpm install`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6861a0b8ed90832b84d8aa623f7c08af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to grant write access, allowing automated processes to push changes to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->