### PR TITLE
Adjust CI tide feed fetch

### DIFF
--- a/.github/workflows/ics.yml
+++ b/.github/workflows/ics.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
-      - run: pnpm build && node dist/cli.js --provider tides --nuke
+      - run: pnpm build && node dist/cli.js --provider tides --days 14
         env:
           STORM_TOKEN: ${{ secrets.STORM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- stop using the nuke option in CI
- fetch two weeks of tide data in each CI run

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68630326cc04832b92f2fbbf547dce71