### PR TITLE
Improve coverage logic

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,33 @@
 import { Command } from "commander";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { differenceInCalendarDays } from "date-fns";
+import { ICalEventData } from "ical-generator";
 import { buildCalendar, loadCalendar } from "./calendar";
 import { loadProvider } from "./providers";
 import { logger, logDir } from "./logger";
+
+export const MIN_COVERAGE = 14;
+export const MAX_COVERAGE = 40;
+
+export function calculateFetchDays(
+  nDays: number,
+  existing: ICalEventData[],
+): { coverage: number; target: number; fetch: number } {
+  const now = new Date();
+  const last = existing.reduce(
+    (max, ev) => {
+      const end = ev.end ?? ev.start;
+      return end > max ? end : max;
+    },
+    now
+  );
+  const coverage = Math.max(0, differenceInCalendarDays(last, now));
+  const target = Math.min(coverage + MIN_COVERAGE, MAX_COVERAGE);
+  const fetch = Math.max(nDays, target);
+  return { coverage, target, fetch };
+}
 
 const program = new Command()
   .name("make-ics")
@@ -23,14 +47,18 @@ const { provider, out, days, nuke } = program.opts() as {
 const nDays = parseInt(days, 10);
 const outFile = out ?? `${provider}.ics`;
 
-(async () => {
+export async function run(): Promise<void> {
   try {
     logger.info({ provider, days: nDays, outFile }, 'start generation');
     const eventProvider = loadProvider(provider);
     const existing = nuke ? [] : loadCalendar(outFile);
-    logger.debug({ existing: existing.length }, 'loaded existing events');
-    const events = await eventProvider.getEvents(nDays);
-    logger.debug({ events: events.length }, 'fetched events');
+    const { coverage, target, fetch } = calculateFetchDays(nDays, existing);
+    logger.debug(
+      { existing: existing.length, coverage, target, fetch },
+      'loaded existing events'
+    );
+    const events = await eventProvider.getEvents(fetch);
+    logger.debug({ events: events.length, fetch }, 'fetched events');
     writeFileSync(
       join(logDir, `${provider}-events.json`),
       JSON.stringify(events, null, 2)
@@ -46,4 +74,8 @@ const outFile = out ?? `${provider}.ics`;
     console.error(`❌ Failed to generate calendar: ${error}`);
     process.exit(1);
   }
-})();
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  run();
+}

--- a/tests/calendar.test.ts
+++ b/tests/calendar.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { buildCalendar, loadCalendar } from "../src/calendar";
 import { dummyProvider } from "../src/providers/dummy";
+import { calculateFetchDays } from "../src/cli";
 import { writeFileSync, rmSync } from "node:fs";
 
 test("dummy provider returns one event", async () => {
@@ -17,4 +18,19 @@ test("loadCalendar parses existing events", async () => {
   expect(parsed.length).toBe(1);
   expect(parsed[0].summary).toBe("Dummy Match");
   rmSync(file);
+});
+
+test("cli extends coverage to at least 34 days", () => {
+  const now = new Date();
+  const existing = [
+    {
+      id: "x",
+      summary: "future",
+      start: now,
+      end: new Date(now.getTime() + 20 * 24 * 60 * 60 * 1000)
+    }
+  ];
+  const { fetch } = calculateFetchDays(7, existing);
+  expect(fetch).toBeGreaterThanOrEqual(34);
+  expect(fetch).toBeLessThanOrEqual(40);
 });


### PR DESCRIPTION
## Summary
- compute coverage and fetch horizon in the CLI
- avoid running the CLI when importing it and export a `run` function
- add test exercising the new horizon calculation

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68655df23230832b8161f3ea363f8faa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved event fetching logic to automatically extend calendar coverage based on existing events, ensuring a minimum future coverage window.
  * Enhanced debug logging to provide more detailed information about event coverage and fetch decisions.

* **Tests**
  * Added a new test to verify that calendar coverage is extended appropriately when fetching events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->