### PR TITLE
Fix CI coverage run and stable tide provider tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  yaml-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      
+      - name: Install yamllint
+        run: pip install yamllint
+      
+      - name: Lint YAML files
+        run: |
+          yamllint -d "{extends: default, rules: {line-length: {max: 120}, truthy: {check-keys: false}}}" .github/workflows/
+  
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhymond/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
         run: node dist/cli.js --provider dummy --days 7
 
       - name: Vitest Coverage Report
-        uses: davelosert/vitest-coverage-report-action@v2        with:
+        uses: davelosert/vitest-coverage-report-action@v2
+        if: always()
+        with:
           json-summary-path: './coverage/coverage-summary.json'
           json-final-path: './coverage/coverage-final.json'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm test --coverage.enabled true
+        run: pnpm test:coverage
 
       - name: Build project
         run: pnpm build
@@ -42,5 +42,4 @@ jobs:
         run: node dist/cli.js --provider dummy --days 7
 
       - name: Report Coverage
-        if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        if: always()        uses: davelosert/vitest-coverage-report-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,5 +41,7 @@ jobs:
       - name: Test CLI (dry run)
         run: node dist/cli.js --provider dummy --days 7
 
-      - name: Report Coverage
-        if: always()        uses: davelosert/vitest-coverage-report-action@v2
+      - name: Vitest Coverage Report
+        uses: davelosert/vitest-coverage-report-action@v2        with:
+          json-summary-path: './coverage/coverage-summary.json'
+          json-final-path: './coverage/coverage-final.json'

--- a/tests/providers/jersey-tides.test.ts
+++ b/tests/providers/jersey-tides.test.ts
@@ -29,7 +29,10 @@ import { writeFileSync } from 'node:fs';
 const mockFetch = fetch as any;
 const mockWriteFileSync = writeFileSync as any;
 
+
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2025-07-08T00:00:00Z"));
   vi.clearAllMocks();
   // Clear environment variables
   delete process.env.STORM_TOKEN;
@@ -37,6 +40,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.resetAllMocks();
 });
 


### PR DESCRIPTION
## Summary
- run vitest coverage correctly in CI
- make `jersey-tides` tests independent of system time

## Testing
- `pnpm test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_686e551f8a7c832bb97411ed63e67d26