### PR TITLE
Extend GitHub Action calendar coverage

### DIFF
--- a/.github/workflows/ics.yml
+++ b/.github/workflows/ics.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: node dist/cli.js --provider tides --days 14
+      - run: node dist/cli.js --provider tides --days 30
         env:
           STORM_TOKEN: ${{ secrets.STORM_TOKEN }}
       - name: Commit calendar and logs


### PR DESCRIPTION
## Summary
- adjust the GitHub Actions workflow to generate 30 days of tide data

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68767f77e0b4832ba5c9de7c4144afb4