### PR TITLE
Fix tide provider range limit

### DIFF
--- a/.github/workflows/ics.yml
+++ b/.github/workflows/ics.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: node dist/cli.js --provider tides --days 14
+      - run: node dist/cli.js --provider tides --days 30
         env:
           STORM_TOKEN: ${{ secrets.STORM_TOKEN }}
       - name: Commit calendar and logs

--- a/src/providers/dummy.ts
+++ b/src/providers/dummy.ts
@@ -1,7 +1,7 @@
 import { EventProvider } from "./types";
 
 export const dummyProvider: EventProvider = {
-  async getEvents(_days?: number) {
+  async getEvents(_days?: number, _offset = 0) {
     return [
       {
         id: "dummy-001",

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,4 @@
 import { ICalEventData } from "ical-generator";
 export interface EventProvider {
-  getEvents(days?: number): Promise<ICalEventData[]>;
+  getEvents(days?: number, offset?: number): Promise<ICalEventData[]>;
 }

--- a/tests/calendar.test.ts
+++ b/tests/calendar.test.ts
@@ -20,7 +20,7 @@ test("loadCalendar parses existing events", async () => {
   rmSync(file);
 });
 
-test("cli extends coverage to at least 34 days", () => {
+test("cli skips fetch when coverage already sufficient", () => {
   const now = new Date();
   const existing = [
     {
@@ -31,8 +31,7 @@ test("cli extends coverage to at least 34 days", () => {
     }
   ];
   const { fetch } = calculateFetchDays(7, existing);
-  expect(fetch).toBeGreaterThanOrEqual(34);
-  expect(fetch).toBeLessThanOrEqual(40);
+  expect(fetch).toBe(0);
 });
 
 test("buildCalendar with timezone", async () => {
@@ -93,8 +92,8 @@ test("calculateFetchDays with existing events beyond max coverage", () => {
   ];
   const { coverage, target, fetch } = calculateFetchDays(7, existing);
   expect(coverage).toBe(50);
-  expect(target).toBe(40); // MAX_COVERAGE
-  expect(fetch).toBe(40);
+  expect(target).toBe(14); // MIN_COVERAGE since nDays < MIN_COVERAGE
+  expect(fetch).toBe(0);
 });
 
 test("calculateFetchDays respects requested days when higher than target", () => {
@@ -109,6 +108,6 @@ test("calculateFetchDays respects requested days when higher than target", () =>
   ];
   const { coverage, target, fetch } = calculateFetchDays(30, existing);
   expect(coverage).toBe(10);
-  expect(target).toBe(24); // coverage + MIN_COVERAGE
-  expect(fetch).toBe(30); // requested days is higher
+  expect(target).toBe(30);
+  expect(fetch).toBe(20);
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -72,18 +72,20 @@ test("calculateFetchDays with existing events", () => {
   ];
   
   const result = calculateFetchDays(7, existing);
-  
+
   expect(result.coverage).toBe(10);
-  expect(result.target).toBe(24); // coverage + MIN_COVERAGE
-  expect(result.fetch).toBe(24);
+  expect(result.target).toBe(14); // MIN_COVERAGE
+  expect(result.fetch).toBe(4);
+  expect(result.offset).toBe(10);
 });
 
 test("calculateFetchDays with no existing events", () => {
   const result = calculateFetchDays(7, []);
-  
+
   expect(result.coverage).toBe(0);
   expect(result.target).toBe(MIN_COVERAGE);
   expect(result.fetch).toBe(MIN_COVERAGE);
+  expect(result.offset).toBe(0);
 });
 
 test("calculateFetchDays respects MAX_COVERAGE", () => {
@@ -98,10 +100,11 @@ test("calculateFetchDays respects MAX_COVERAGE", () => {
   ];
   
   const result = calculateFetchDays(7, existing);
-  
+
   expect(result.coverage).toBe(50);
-  expect(result.target).toBe(MAX_COVERAGE);
-  expect(result.fetch).toBe(MAX_COVERAGE);
+  expect(result.target).toBe(MIN_COVERAGE);
+  expect(result.fetch).toBe(0);
+  expect(result.offset).toBe(50);
 });
 
 test("calculateFetchDays uses requested days when higher than target", () => {
@@ -116,10 +119,11 @@ test("calculateFetchDays uses requested days when higher than target", () => {
   ];
   
   const result = calculateFetchDays(30, existing);
-  
+
   expect(result.coverage).toBe(5);
-  expect(result.target).toBe(19); // coverage + MIN_COVERAGE
-  expect(result.fetch).toBe(30); // requested days is higher
+  expect(result.target).toBe(30);
+  expect(result.fetch).toBe(25);
+  expect(result.offset).toBe(5);
 });
 
 test("calculateFetchDays handles events with only start date", () => {
@@ -134,10 +138,11 @@ test("calculateFetchDays handles events with only start date", () => {
   ];
   
   const result = calculateFetchDays(7, existing);
-  
+
   expect(result.coverage).toBe(5);
-  expect(result.target).toBe(19);
-  expect(result.fetch).toBe(19);
+  expect(result.target).toBe(14);
+  expect(result.fetch).toBe(9);
+  expect(result.offset).toBe(5);
 });
 
 test("run function executes successfully", async () => {
@@ -156,9 +161,9 @@ test("run function executes successfully", async () => {
   mockLoadCalendar.mockReturnValue([]);
   
   await run();
-  
+
   expect(mockLoadProvider).toHaveBeenCalledWith("dummy");
-  expect(mockProvider.getEvents).toHaveBeenCalled();
+  expect(mockProvider.getEvents).toHaveBeenCalledWith(MIN_COVERAGE, 0);
   expect(mockBuildCalendar).toHaveBeenCalled();
   expect(mockWriteFileSync).toHaveBeenCalledWith(
     "dummy.ics",


### PR DESCRIPTION
## Summary
- fetch tide data in chunks to bypass API range limit
- adjust tests accordingly
- compute start offset from existing calendar and only fetch missing days

## Testing
- `pnpm exec vitest run`
- `pnpm run check:yaml`

------
https://chatgpt.com/codex/tasks/task_e_68767f77e0b4832ba5c9de7c4144afb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended calendar data coverage from 14 to 30 days when generating ICS files.
  * Improved tide event provider to support fetching data in multiple chunks and applying date offsets.

* **Bug Fixes**
  * Adjusted logic to prevent unnecessary data fetching when existing coverage is sufficient.

* **Tests**
  * Updated and added tests to cover new fetch logic, chunked data retrieval, and offset handling for tide events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->